### PR TITLE
make image which width is  the integral multiple of mcu width work

### DIFF
--- a/jpeg_read.py
+++ b/jpeg_read.py
@@ -611,7 +611,7 @@ def combine_blocks(data):
          for xb in range(xbmax):
             out[yb+offsety][xb+offsetx]= tuple(block[yb][xb])
       offsetx+= xbmax
-      if offsetx>X:
+      if offsetx>=X:
          offsetx= 0
          offsety+= ybmax
 


### PR DESCRIPTION
原本採用"大於"，當寬度剛好為mcu整數倍時，會將下一個mcu放在同一行，導致這一行多了一個mcu

originally use ">", if image width is the multiple of mcu width, it will put next mcu in the same line, which cause this line have extra mcu
